### PR TITLE
operators finish

### DIFF
--- a/kubernetes-operators/README.md
+++ b/kubernetes-operators/README.md
@@ -1,0 +1,53 @@
+# AlexClev_platform
+Создан кластер на базе minicube
+Создан манифест CRD согласно методичке, получена ошибка 
+"The CustomResourceDefinition "mysqls.otus.homework" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required"
+Манифест дополнен описанием схему, согласно https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
+При попытке применения Cr.yml получаем ошибку 
+Error from server (BadRequest): error when creating "cr.yml": MySQL in version "v1" cannot be handled as a MySQL: strict decoding error: unknown field "spec.database", unknown field "spec.image", unknown field "spec.password", unknown field "spec.storage_size", unknown field "usless_data"
+Из чего, помянув добрым словом составителей методички,  делаем вывод, что схема была описана в CDR не полностью и корректруем crd.yml добавлением полей из ошибки и Cr.yml удалением строки с "usless_data"
+Успешно применяем оба манифеста
+Проверяем взаимодействие с созданными объектами и доходми до раздела Validation ДЗ, где с удивллением обнаруживаем поля, которые нужно было добавить ранее.
+Валидацтю пропускаем, так как формат жёстко указан ранее.
+Перерыв материалы лекций и не найдя подсказок по описанию обязательный полей в CustomResourceDefinition, снова идём читать документацию
+Добавляем строчку в CRD:  required: ["image", "database", "password", "storage_size"]
+Установлен python3 и требуемые модули, созданы шаблоны jinja2 и запущен скрипт mysqloperator.py
+$ kopf run  mysqloperator.py
+/usr/local/lib/python3.10/dist-packages/kopf/_core/reactor/running.py:179: FutureWarning: Absence of either namespaces or cluster-wide flag will become an error soon. For now, switching to the cluster-wide mode for backward compatibility.
+  warnings.warn("Absence of either namespaces or cluster-wide flag will become an error soon."
+[2023-12-09 18:35:23,667] kopf._core.engines.a [INFO    ] Initial authentication has been initiated.
+[2023-12-09 18:35:23,684] kopf.activities.auth [INFO    ] Activity 'login_via_client' succeeded.
+[2023-12-09 18:35:23,685] kopf._core.engines.a [INFO    ] Initial authentication has finished.
+/var/homework/operators/build/mysqloperator.py:13: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
+  json_manifest = yaml.load(yaml_manifest)
+[2023-12-09 18:35:24,060] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'mysql_on_create' succeeded.
+[2023-12-09 18:35:24,060] kopf.objects         [INFO    ] [default/mysql-instance] Creation is processed: 1 succeeded; 0 failed.
+Удаляем ресурсы, созданные контроллером и дополняем скрипт определением дочерний объектов и  обработкой события удаления ресурса mysql, перезапускаем скрипт и прорлучаем новую ошибку:
+"NameError: name 'restore_job' is not defined" - понятно, опять ошибка в методичке, правим сами, добавляя раздел с restore_job и запускаем скрипт ещё раз - успех.
+
+Проводим манипудяци с добавлением фрагметов скрипта по удалению Job, запускаем скрипт и снова ловим новую ошибку. Перерыв кучу документации, узнаёю про финализаторы, которые не дают корректно удалить объекты из-за чего происходит конфликт.  Запускаем kubectl get MySQL -A -o yaml, узнаём имена и запускаем kubectl patch MYSQL/mysql-instance -p '{"metadata":{"finalizers":[]}}' --type=merge. После чего снова успех.
+
+Проверяем:
+$ kubectl get pvc
+NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+backup-mysql-instance-pvc   Bound    pvc-03ec9b5e-87e9-4260-9a3c-73bd1b98d215   1Gi        RWO            standard       4m29s
+mysql-instance-pvc          Bound    pvc-18e13e69-2810-4d80-894d-c286ceb50cf0   1Gi        RWO            standard       4m29s
+
+Заполняем данными и проверяем:
+
+$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
+mysql: [Warning] Using a password on the command line interface can be insecure.
++----+-------------+
+| id | name        |
++----+-------------+
+|  1 | some data   |
+|  2 | some data-2 |
++----+-------------+
+
+
+ 
+
+
+
+
+

--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+COPY templates ./templates
+COPY mysqloperator.py ./mysqloperator.py
+RUN pip install kopf kubernetes pyyaml jinja2
+CMD kopf run ./mysqloperator.py

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.load(yaml_manifest)
+    return json_manifest
+
+def delete_success_jobs(mysql_instance_name):
+    print('start deletion')
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+        jobname = job.metadata.name
+        if jobname in [f'backup-{mysql_instance_name}-job', f'restore-{mysql_instance_name}-job', f'change-password-{mysql_instance_name}-job']:
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname, 'default', propagation_policy='Background')
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                print(f'job with name {jobname} found, waiting until end')
+                if job.status.succeeded == 1:
+                    print(f'job with {jobname} is successful')
+                    job_finished = True 
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+# Функция, которая будет запускаться при создании объектов тип MySQL:
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2',
+                                        {'name': name,
+                                         'storage_size': storage_size})
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2',
+                                              {'name': name,
+                                               'storage_size': storage_size})
+    service = render_template('mysql-service.yml.j2', {'name': name})
+
+    deployment = render_template('mysql-deployment.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    
+    restore_job = render_template('restore-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+
+  # Определяем, что созданные ресурсы являются дочерними к управляемому CustomResource:
+    kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body)
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+    kopf.append_owner_reference(restore_job, owner=body)
+    # ^ Таким образом при удалении CR удалятся все, связанные с ним pv, pvc, svc, deployments
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    api.create_persistent_volume(persistent_volume)
+    # Создаем mysql PVC:
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+
+    # Cоздаем PVC и PV для бэкапов:
+    try:
+        backup_pv = render_template('backup-pv.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        api.create_persistent_volume(backup_pv)
+    except kubernetes.client.rest.ApiException:
+        pass
+    try:
+        backup_pvc = render_template('backup-pvc.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+    except kubernetes.client.rest.ApiException:
+        pass
+ 
+   # Пытаемся восстановиться из backup
+    try:
+        api = kubernetes.client.BatchV1Api()
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        pass
+   
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+   
+    delete_success_jobs(name)
+    
+    # Cоздаем backup job:
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+    return {'message': "mysql and its children resources deleted"}

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /data/pv-backup/

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "1Gi"
+  selector:
+    matchLabels:
+      pv-usage: "backup-{{ name }}"

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+        args:
+        - "--ignore-db-dir=lost+found"
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/{{ name }}-pv/

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}
+  selector:
+    matchLabels:
+      pv-usage: {{ name }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup
+        image: mysql:5.7
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }}< /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,10 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+ name: mysql-instance
+spec:
+ image: mysql:5.7
+ database: otus-database
+ password: otuspassword # Так делать не нужно, следует использовать secret
+ storage_size: 1Gi
+

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              properties:
+                database:
+                  type: string
+                image:
+                  type: string
+                password: 
+                  type: string
+                storage_size:
+                  type: string    
+              type: object 
+              required: ["image", "database", "password", "storage_size"]  
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "cleverok2/mysql-operator:v0.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ №

 - [*] Основное ДЗ
 - [ ] Задание со *
 
Создан кластер на базе minicube
Создан манифест CRD согласно методичке, получена ошибка 
"The CustomResourceDefinition "mysqls.otus.homework" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required"
Манифест дополнен описанием схему, согласно https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
При попытке применения Cr.yml получаем ошибку 
Error from server (BadRequest): error when creating "cr.yml": MySQL in version "v1" cannot be handled as a MySQL: strict decoding error: unknown field "spec.database", unknown field "spec.image", unknown field "spec.password", unknown field "spec.storage_size", unknown field "usless_data"
Из чего, помянув добрым словом составителей методички,  делаем вывод, что схема была описана в CDR не полностью и корректируем crd.yml добавлением полей из ошибки и Cr.yml удалением строки с "usless_data"
Успешно применяем оба манифеста
Проверяем взаимодействие с созданными объектами и доходим до раздела Validation ДЗ, где с удивлением обнаруживаем поля, которые нужно было добавить ранее.
Валидацию пропускаем, так как формат жёстко указан ранее.
Перерыв материалы лекций и не найдя подсказок по описанию обязательный полей в CustomResourceDefinition, снова идём читать документацию
Добавляем строчку в CRD:  required: ["image", "database", "password", "storage_size"]
Установлен python3 и требуемые модули, созданы шаблоны jinja2 и запущен скрипт mysqloperator.py

Удаляем ресурсы, созданные контроллером и дополняем скрипт определением дочерний объектов и  обработкой события удаления ресурса mysql, перезапускаем скрипт и получаем новую ошибку:
"NameError: name 'restore_job' is not defined" - понятно, опять ошибка в методичке, правим сами, добавляя раздел с restore_job и запускаем скрипт ещё раз - успех.

Проводим манипуляции с добавлением фрагментов скрипта по удалению Job, запускаем скрипт и снова ловим новую ошибку. Перерыв кучу документации, узнаём про финализаторы, которые не дают корректно удалить объекты из-за чего происходит конфликт.  Запускаем kubectl get MySQL -A -o yaml, узнаём имена и запускаем kubectl patch MYSQL/mysql-instance -p '{"metadata":{"finalizers":[]}}' --type=merge. После чего снова успех.

аполняем данными и проверяем:

$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
mysql: [Warning] Using a password on the command line interface can be insecure.
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+

## PR checklist:
 - [ * ] Выставлен label с темой домашнего задания
